### PR TITLE
added condition for if song is already playing

### DIFF
--- a/js/bootstrap3_player.js
+++ b/js/bootstrap3_player.js
@@ -51,7 +51,7 @@
                         song.play();
                     });
                 }
-                if (toggle === 'pause') {
+                if (!song.paused || toggle === 'pause') {
                     $(play).html('<i class="glyphicon glyphicon-pause"></i>');
                     $(play).click(function () {
                         song.pause();

--- a/js/bootstrap3_player.js
+++ b/js/bootstrap3_player.js
@@ -67,6 +67,11 @@
             var timeout = 0;
 
             var loadCheck = setInterval(function () {
+                if (!song.paused){
+                    play.setPlayState('pause');
+                    clearInterval(loadCheck);
+                    return true;
+                }
                 if (isNaN(song.duration) === false) {
                     play.setPlayState('play');
                     clearInterval(loadCheck);


### PR DESCRIPTION
If the audio element getting changed included an `autoplay` attribute, causing the audio to automatically play, the pause/play button would not change to the pause state or respond at all. This is just a condition to make sure it is in the pause state if already playing.

Edit: Added another fix for setting the button back to the pause state when finished sliding and the audio still plays.
